### PR TITLE
fix: pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/nctl-scan-dockerfile.yaml
+++ b/.github/workflows/nctl-scan-dockerfile.yaml
@@ -15,7 +15,7 @@ jobs:
       - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
 
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Download and Install NCTL
         run: |

--- a/.github/workflows/nctl-scan-k8s.yaml
+++ b/.github/workflows/nctl-scan-k8s.yaml
@@ -12,7 +12,7 @@ jobs:
       - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
 
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Download and Install NCTL
         run: |

--- a/.github/workflows/nctl-scan-terraform.yaml
+++ b/.github/workflows/nctl-scan-terraform.yaml
@@ -16,7 +16,7 @@ jobs:
       - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
 
       - name: Checkout PR branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
         with:
           # Checks out the repository linked to the PR
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -24,7 +24,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355  # v2
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: nctl-scan-terraform-${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/scan-outputs.yaml
+++ b/.github/workflows/scan-outputs.yaml
@@ -14,10 +14,10 @@ jobs:
       - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
 
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: nctl-scan-installer
-        uses: nirmata/action-install-nctl-scan@v0.0.4
+        uses: nirmata/action-install-nctl-scan@aef60bc2f1608594ba2798f0a965ee8716b9400b  # v0.0.4
 
       - run: echo "🖥️ The workflow is now ready to test your code on the runner."
 


### PR DESCRIPTION
## Summary

Pins all GitHub Actions `uses:` references to full commit SHAs to prevent supply chain attacks via tag mutation.

### Changes
- `actions/checkout@v4 -> @34e11487...`
- `actions/checkout@v4 -> @34e11487...`
- `actions/checkout@v3 -> @f43a0e5f...`
- `aws-actions/configure-aws-credentials@v2 -> @5fd3084f...`
- `actions/checkout@v4 -> @34e11487...`
- `nirmata/action-install-nctl-scan@v0.0.4 -> @aef60bc2...`


### Why

Following the [TeamPCP/Checkmarx supply chain attack](https://thehackernews.com/2026/03/teampcp-hacks-checkmarx-github-actions.html), Nirmata is hardening all public repos against GitHub Actions tag hijacking. This repo was flagged as **CRITICAL** (unpinned actions + write permissions).

Tracked in: https://github.com/nirmata/platform-engineering-policies/issues/33
