### PR TITLE
Validate NDEV-20537: build nctl from source

### DIFF
--- a/.github/workflows/nctl-scan-dockerfile.yaml
+++ b/.github/workflows/nctl-scan-dockerfile.yaml
@@ -17,13 +17,25 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
 
-      - name: Download and Install NCTL
+      - name: Check out go-nctl (NDEV-20537)
+        uses: actions/checkout@v4
+        with:
+          repository: nirmata/go-nctl
+          ref: NDEV-20537
+          token: ${{ secrets.GO_NCTL_READ_TOKEN }}
+          path: go-nctl
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go-nctl/go.mod
+
+      - name: Build nctl from source
         run: |
-          echo "Downloading and Installing NCTL"
-          wget https://nirmata-downloads.s3.us-east-2.amazonaws.com/nctl/nctl_4.7.8-rc.2/nctl_4.7.8-rc.2_linux_386.zip  
-          unzip -o *.zip
-          chmod 755 ./nctl
+          cd go-nctl
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o nctl .
           sudo mv nctl /usr/local/bin/nctl
+
       - run: echo "🖥️ The workflow is now ready to test your code on the runner."
 
       - name: Check nctl version
@@ -34,6 +46,6 @@ jobs:
           nctl login --url https://www.nirmata.io --userid dolis@nirmata.com --token ${{ secrets.NIRMATA_TOKEN }}
 
       - name: NCTL Scan - Dockerfile
-        run: nctl scan dockerfile --policies controls/dockerfile-best-practices --resources config-files/dockerfile/Dockerfile --publish
+        run: nctl scan dockerfile --policies controls/dockerfile-best-practices --resources config-files/dockerfile/Dockerfile --publish --pipeline 0
   
       - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/.github/workflows/nctl-scan-dockerfile.yaml
+++ b/.github/workflows/nctl-scan-dockerfile.yaml
@@ -18,21 +18,14 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
 
-      - name: Download nctl artifact from go-nctl (NDEV-20537)
-        uses: dawidd6/action-download-artifact@v6
-        with:
-          github_token: ${{ secrets.GO_NCTL_READ_TOKEN }}
-          repo: nirmata/go-nctl
-          branch: NDEV-20537
-          workflow: ci.yaml
-          name: nctl-binary
-          check_artifacts: true
-          workflow_conclusion: ""
-
-      - name: Install nctl
+      - name: Install latest nctl
         run: |
+          gh release download --repo nirmata/go-nctl --pattern "nctl_*_linux_amd64.zip" --output nctl.zip
+          unzip -o nctl.zip nctl
           chmod +x nctl
           sudo mv nctl /usr/local/bin/nctl
+        env:
+          GH_TOKEN: ${{ secrets.GO_NCTL_READ_TOKEN }}
 
       - run: echo "🖥️ The workflow is now ready to test your code on the runner."
 
@@ -44,6 +37,6 @@ jobs:
           nctl login --url https://www.nirmata.io --userid dolis@nirmata.com --token ${{ secrets.NIRMATA_TOKEN }}
 
       - name: NCTL Scan - Dockerfile
-        run: nctl scan dockerfile --policies controls/dockerfile-best-practices --resources config-files/dockerfile/Dockerfile --publish --pipeline=false
+        run: nctl scan dockerfile --policies controls/dockerfile-best-practices --resources config-files/dockerfile/Dockerfile --publish
   
       - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/.github/workflows/nctl-scan-dockerfile.yaml
+++ b/.github/workflows/nctl-scan-dockerfile.yaml
@@ -31,7 +31,12 @@ jobs:
         with:
           go-version-file: go-nctl/go.mod
 
+      - name: Configure git for private nirmata deps
+        run: git config --global url."https://oauth2:${{ secrets.GO_NCTL_READ_TOKEN }}@github.com/nirmata/".insteadOf "https://github.com/nirmata/"
+
       - name: Build nctl from source
+        env:
+          GOPRIVATE: github.com/nirmata/*
         run: |
           cd go-nctl
           CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o nctl .

--- a/.github/workflows/nctl-scan-dockerfile.yaml
+++ b/.github/workflows/nctl-scan-dockerfile.yaml
@@ -27,6 +27,7 @@ jobs:
           workflow: ci.yaml
           name: nctl-binary
           check_artifacts: true
+          workflow_conclusion: ""
 
       - name: Install nctl
         run: |

--- a/.github/workflows/nctl-scan-dockerfile.yaml
+++ b/.github/workflows/nctl-scan-dockerfile.yaml
@@ -11,6 +11,7 @@ on:
 jobs:
   NCTL-Scan-Dockerfile:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
 

--- a/.github/workflows/nctl-scan-dockerfile.yaml
+++ b/.github/workflows/nctl-scan-dockerfile.yaml
@@ -44,6 +44,6 @@ jobs:
           nctl login --url https://www.nirmata.io --userid dolis@nirmata.com --token ${{ secrets.NIRMATA_TOKEN }}
 
       - name: NCTL Scan - Dockerfile
-        run: nctl scan dockerfile --policies controls/dockerfile-best-practices --resources config-files/dockerfile/Dockerfile --publish --pipeline 0
+        run: nctl scan dockerfile --policies controls/dockerfile-best-practices --resources config-files/dockerfile/Dockerfile --publish --pipeline=false
   
       - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/.github/workflows/nctl-scan-dockerfile.yaml
+++ b/.github/workflows/nctl-scan-dockerfile.yaml
@@ -18,28 +18,19 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
 
-      - name: Check out go-nctl (NDEV-20537)
-        uses: actions/checkout@v4
+      - name: Download nctl artifact from go-nctl (NDEV-20537)
+        uses: dawidd6/action-download-artifact@v6
         with:
-          repository: nirmata/go-nctl
-          ref: NDEV-20537
-          token: ${{ secrets.GO_NCTL_READ_TOKEN }}
-          path: go-nctl
+          github_token: ${{ secrets.GO_NCTL_READ_TOKEN }}
+          repo: nirmata/go-nctl
+          branch: NDEV-20537
+          workflow: ci.yaml
+          name: nctl-binary
+          check_artifacts: true
 
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go-nctl/go.mod
-
-      - name: Configure git for private nirmata deps
-        run: git config --global url."https://oauth2:${{ secrets.GO_NCTL_READ_TOKEN }}@github.com/nirmata/".insteadOf "https://github.com/nirmata/"
-
-      - name: Build nctl from source
-        env:
-          GOPRIVATE: github.com/nirmata/*
+      - name: Install nctl
         run: |
-          cd go-nctl
-          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o nctl .
+          chmod +x nctl
           sudo mv nctl /usr/local/bin/nctl
 
       - run: echo "🖥️ The workflow is now ready to test your code on the runner."

--- a/.github/workflows/nctl-scan-k8s-latest.yaml
+++ b/.github/workflows/nctl-scan-k8s-latest.yaml
@@ -1,0 +1,40 @@
+name: NCTL Scan K8s (Latest Release)
+run-name: ${{ github.actor }} has triggered Scan Action 🚀
+on:
+  pull_request:
+    branches:
+      - "main"
+
+jobs:
+  NCTL-Scan-K8s-Latest:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
+
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - name: Install latest nctl
+        run: |
+          LATEST=$(gh release view --repo nirmata/go-nctl --json tagName --jq '.tagName' | sed 's/^v//')
+          curl -sL "https://github.com/nirmata/go-nctl/releases/latest/download/nctl_${LATEST}_linux_amd64.zip" -o nctl.zip
+          unzip -o nctl.zip nctl
+          chmod +x nctl
+          sudo mv nctl /usr/local/bin/nctl
+        env:
+          GH_TOKEN: ${{ secrets.GO_NCTL_READ_TOKEN }}
+
+      - run: echo "🖥️ The workflow is now ready to test your code on the runner."
+
+      - name: Check nctl version
+        run: nctl version
+
+      - name: Login to Nirmata
+        run: |
+          nctl login --url https://www.nirmata.io --userid dolis@nirmata.com --token ${{ secrets.NIRMATA_TOKEN }}
+
+      - name: NCTL Scan - Kubernetes
+        run: nctl scan kubernetes --resources config-files/k8s --publish
+
+      - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/.github/workflows/nctl-scan-k8s-latest.yaml
+++ b/.github/workflows/nctl-scan-k8s-latest.yaml
@@ -17,8 +17,7 @@ jobs:
 
       - name: Install latest nctl
         run: |
-          LATEST=$(gh release view --repo nirmata/go-nctl --json tagName --jq '.tagName' | sed 's/^v//')
-          curl -sL "https://github.com/nirmata/go-nctl/releases/latest/download/nctl_${LATEST}_linux_amd64.zip" -o nctl.zip
+          gh release download --repo nirmata/go-nctl --pattern "nctl_*_linux_amd64.zip" --output nctl.zip
           unzip -o nctl.zip nctl
           chmod +x nctl
           sudo mv nctl /usr/local/bin/nctl

--- a/.github/workflows/nctl-scan-k8s.yaml
+++ b/.github/workflows/nctl-scan-k8s.yaml
@@ -14,13 +14,25 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
 
-      - name: Download and Install NCTL
+      - name: Check out go-nctl (NDEV-20537)
+        uses: actions/checkout@v4
+        with:
+          repository: nirmata/go-nctl
+          ref: NDEV-20537
+          token: ${{ secrets.GO_NCTL_READ_TOKEN }}
+          path: go-nctl
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go-nctl/go.mod
+
+      - name: Build nctl from source
         run: |
-          echo "Downloading and Installing NCTL"
-          wget https://nirmata-downloads.s3.us-east-2.amazonaws.com/nctl/nctl_4.10.1/nctl_4.10.1_linux_386.zip 
-          unzip -o *.zip
-          chmod 755 ./nctl
+          cd go-nctl
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o nctl .
           sudo mv nctl /usr/local/bin/nctl
+
       - run: echo "🖥️ The workflow is now ready to test your code on the runner."
 
       - name: Check nctl version
@@ -31,7 +43,7 @@ jobs:
           nctl login --url https://www.nirmata.io --userid dolis@nirmata.com --token ${{ secrets.NIRMATA_TOKEN }}
 
       - name: NCTL Scan - Kubernetes
-        run: nctl scan kubernetes --resources config-files/k8s --publish
+        run: nctl scan kubernetes --resources config-files/k8s --publish --pipeline 0
 
 
       - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/.github/workflows/nctl-scan-k8s.yaml
+++ b/.github/workflows/nctl-scan-k8s.yaml
@@ -15,21 +15,14 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
 
-      - name: Download nctl artifact from go-nctl (NDEV-20537)
-        uses: dawidd6/action-download-artifact@v6
-        with:
-          github_token: ${{ secrets.GO_NCTL_READ_TOKEN }}
-          repo: nirmata/go-nctl
-          branch: NDEV-20537
-          workflow: ci.yaml
-          name: nctl-binary
-          check_artifacts: true
-          workflow_conclusion: ""
-
-      - name: Install nctl
+      - name: Install latest nctl
         run: |
+          gh release download --repo nirmata/go-nctl --pattern "nctl_*_linux_amd64.zip" --output nctl.zip
+          unzip -o nctl.zip nctl
           chmod +x nctl
           sudo mv nctl /usr/local/bin/nctl
+        env:
+          GH_TOKEN: ${{ secrets.GO_NCTL_READ_TOKEN }}
 
       - run: echo "🖥️ The workflow is now ready to test your code on the runner."
 
@@ -41,7 +34,7 @@ jobs:
           nctl login --url https://www.nirmata.io --userid dolis@nirmata.com --token ${{ secrets.NIRMATA_TOKEN }}
 
       - name: NCTL Scan - Kubernetes
-        run: nctl scan kubernetes --resources config-files/k8s --publish --pipeline=false
+        run: nctl scan kubernetes --resources config-files/k8s --publish
 
 
       - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/.github/workflows/nctl-scan-k8s.yaml
+++ b/.github/workflows/nctl-scan-k8s.yaml
@@ -41,7 +41,7 @@ jobs:
           nctl login --url https://www.nirmata.io --userid dolis@nirmata.com --token ${{ secrets.NIRMATA_TOKEN }}
 
       - name: NCTL Scan - Kubernetes
-        run: nctl scan kubernetes --resources config-files/k8s --publish --pipeline 0
+        run: nctl scan kubernetes --resources config-files/k8s --publish --pipeline=false
 
 
       - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/.github/workflows/nctl-scan-k8s.yaml
+++ b/.github/workflows/nctl-scan-k8s.yaml
@@ -24,6 +24,7 @@ jobs:
           workflow: ci.yaml
           name: nctl-binary
           check_artifacts: true
+          workflow_conclusion: ""
 
       - name: Install nctl
         run: |

--- a/.github/workflows/nctl-scan-k8s.yaml
+++ b/.github/workflows/nctl-scan-k8s.yaml
@@ -8,6 +8,7 @@ on:
 jobs:
   NCTL-Scan-K8s:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
 

--- a/.github/workflows/nctl-scan-k8s.yaml
+++ b/.github/workflows/nctl-scan-k8s.yaml
@@ -15,28 +15,19 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
 
-      - name: Check out go-nctl (NDEV-20537)
-        uses: actions/checkout@v4
+      - name: Download nctl artifact from go-nctl (NDEV-20537)
+        uses: dawidd6/action-download-artifact@v6
         with:
-          repository: nirmata/go-nctl
-          ref: NDEV-20537
-          token: ${{ secrets.GO_NCTL_READ_TOKEN }}
-          path: go-nctl
+          github_token: ${{ secrets.GO_NCTL_READ_TOKEN }}
+          repo: nirmata/go-nctl
+          branch: NDEV-20537
+          workflow: ci.yaml
+          name: nctl-binary
+          check_artifacts: true
 
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go-nctl/go.mod
-
-      - name: Configure git for private nirmata deps
-        run: git config --global url."https://oauth2:${{ secrets.GO_NCTL_READ_TOKEN }}@github.com/nirmata/".insteadOf "https://github.com/nirmata/"
-
-      - name: Build nctl from source
-        env:
-          GOPRIVATE: github.com/nirmata/*
+      - name: Install nctl
         run: |
-          cd go-nctl
-          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o nctl .
+          chmod +x nctl
           sudo mv nctl /usr/local/bin/nctl
 
       - run: echo "🖥️ The workflow is now ready to test your code on the runner."

--- a/.github/workflows/nctl-scan-k8s.yaml
+++ b/.github/workflows/nctl-scan-k8s.yaml
@@ -28,7 +28,12 @@ jobs:
         with:
           go-version-file: go-nctl/go.mod
 
+      - name: Configure git for private nirmata deps
+        run: git config --global url."https://oauth2:${{ secrets.GO_NCTL_READ_TOKEN }}@github.com/nirmata/".insteadOf "https://github.com/nirmata/"
+
       - name: Build nctl from source
+        env:
+          GOPRIVATE: github.com/nirmata/*
         run: |
           cd go-nctl
           CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o nctl .

--- a/.github/workflows/nctl-scan-terraform.yaml
+++ b/.github/workflows/nctl-scan-terraform.yaml
@@ -31,28 +31,19 @@ jobs:
           role-session-name: nctl-scan-terraform-${{ github.event.pull_request.head.ref }}
           aws-region: us-west-2
 
-      - name: Check out go-nctl (NDEV-20537)
-        uses: actions/checkout@v4
+      - name: Download nctl artifact from go-nctl (NDEV-20537)
+        uses: dawidd6/action-download-artifact@v6
         with:
-          repository: nirmata/go-nctl
-          ref: NDEV-20537
-          token: ${{ secrets.GO_NCTL_READ_TOKEN }}
-          path: go-nctl
+          github_token: ${{ secrets.GO_NCTL_READ_TOKEN }}
+          repo: nirmata/go-nctl
+          branch: NDEV-20537
+          workflow: ci.yaml
+          name: nctl-binary
+          check_artifacts: true
 
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go-nctl/go.mod
-
-      - name: Configure git for private nirmata deps
-        run: git config --global url."https://oauth2:${{ secrets.GO_NCTL_READ_TOKEN }}@github.com/nirmata/".insteadOf "https://github.com/nirmata/"
-
-      - name: Build nctl from source
-        env:
-          GOPRIVATE: github.com/nirmata/*
+      - name: Install nctl
         run: |
-          cd go-nctl
-          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o nctl .
+          chmod +x nctl
           sudo mv nctl /usr/local/bin/nctl
 
       - run: echo "🖥️ The workflow is now ready to test your code on the runner."

--- a/.github/workflows/nctl-scan-terraform.yaml
+++ b/.github/workflows/nctl-scan-terraform.yaml
@@ -40,6 +40,7 @@ jobs:
           workflow: ci.yaml
           name: nctl-binary
           check_artifacts: true
+          workflow_conclusion: ""
 
       - name: Install nctl
         run: |

--- a/.github/workflows/nctl-scan-terraform.yaml
+++ b/.github/workflows/nctl-scan-terraform.yaml
@@ -30,13 +30,25 @@ jobs:
           role-session-name: nctl-scan-terraform-${{ github.event.pull_request.head.ref }}
           aws-region: us-west-2
 
-      - name: Download and Install NCTL
+      - name: Check out go-nctl (NDEV-20537)
+        uses: actions/checkout@v4
+        with:
+          repository: nirmata/go-nctl
+          ref: NDEV-20537
+          token: ${{ secrets.GO_NCTL_READ_TOKEN }}
+          path: go-nctl
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go-nctl/go.mod
+
+      - name: Build nctl from source
         run: |
-          echo "Downloading and Installing NCTL"
-          wget https://nirmata-downloads.s3.us-east-2.amazonaws.com/nctl/nctl_4.10.1/nctl_4.10.1_linux_386.zip  
-          unzip -o *.zip
-          chmod 755 ./nctl
+          cd go-nctl
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o nctl .
           sudo mv nctl /usr/local/bin/nctl
+
       - run: echo "🖥️ The workflow is now ready to test your code on the runner."
 
       - name: Check nctl version
@@ -53,7 +65,7 @@ jobs:
 
       - name: NCTL Scan - Terraform
         run: |
-          nctl scan terraform --policies controls/cis-eks/infrastructure --resources config-files/terraform/eks/payload.json --publish
+          nctl scan terraform --policies controls/cis-eks/infrastructure --resources config-files/terraform/eks/payload.json --publish --pipeline 0
 
           
   

--- a/.github/workflows/nctl-scan-terraform.yaml
+++ b/.github/workflows/nctl-scan-terraform.yaml
@@ -31,21 +31,14 @@ jobs:
           role-session-name: nctl-scan-terraform-${{ github.event.pull_request.head.ref }}
           aws-region: us-west-2
 
-      - name: Download nctl artifact from go-nctl (NDEV-20537)
-        uses: dawidd6/action-download-artifact@v6
-        with:
-          github_token: ${{ secrets.GO_NCTL_READ_TOKEN }}
-          repo: nirmata/go-nctl
-          branch: NDEV-20537
-          workflow: ci.yaml
-          name: nctl-binary
-          check_artifacts: true
-          workflow_conclusion: ""
-
-      - name: Install nctl
+      - name: Install latest nctl
         run: |
+          gh release download --repo nirmata/go-nctl --pattern "nctl_*_linux_amd64.zip" --output nctl.zip
+          unzip -o nctl.zip nctl
           chmod +x nctl
           sudo mv nctl /usr/local/bin/nctl
+        env:
+          GH_TOKEN: ${{ secrets.GO_NCTL_READ_TOKEN }}
 
       - run: echo "🖥️ The workflow is now ready to test your code on the runner."
 
@@ -63,7 +56,7 @@ jobs:
 
       - name: NCTL Scan - Terraform
         run: |
-          nctl scan terraform --policies controls/cis-eks/infrastructure --resources config-files/terraform/eks/payload.json --publish --pipeline=false
+          nctl scan terraform --policies controls/cis-eks/infrastructure --resources config-files/terraform/eks/payload.json --publish
 
           
   

--- a/.github/workflows/nctl-scan-terraform.yaml
+++ b/.github/workflows/nctl-scan-terraform.yaml
@@ -44,7 +44,12 @@ jobs:
         with:
           go-version-file: go-nctl/go.mod
 
+      - name: Configure git for private nirmata deps
+        run: git config --global url."https://oauth2:${{ secrets.GO_NCTL_READ_TOKEN }}@github.com/nirmata/".insteadOf "https://github.com/nirmata/"
+
       - name: Build nctl from source
+        env:
+          GOPRIVATE: github.com/nirmata/*
         run: |
           cd go-nctl
           CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o nctl .

--- a/.github/workflows/nctl-scan-terraform.yaml
+++ b/.github/workflows/nctl-scan-terraform.yaml
@@ -63,7 +63,7 @@ jobs:
 
       - name: NCTL Scan - Terraform
         run: |
-          nctl scan terraform --policies controls/cis-eks/infrastructure --resources config-files/terraform/eks/payload.json --publish --pipeline 0
+          nctl scan terraform --policies controls/cis-eks/infrastructure --resources config-files/terraform/eks/payload.json --publish --pipeline=false
 
           
   

--- a/.github/workflows/nctl-scan-terraform.yaml
+++ b/.github/workflows/nctl-scan-terraform.yaml
@@ -8,6 +8,7 @@ on:
 jobs:
   NCTL-Scan-Terraform:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
     # These permissions are needed to interact with GitHub's OIDC Token endpoint
     permissions:
       id-token: write   # This is required for requesting the JWT


### PR DESCRIPTION
## Summary
- Replaces pre-built nctl binary download with a checkout of `nirmata/go-nctl` at branch `NDEV-20537` and a from-source build
- Uses `GO_NCTL_READ_TOKEN` secret (fine-grained PAT, read-only on `nirmata/go-nctl`) for the private repo checkout
- Adds `--pipeline 0` to all scan commands so workflow steps don't fail during validation

## Test plan
- [ ] `nctl-scan-dockerfile` workflow runs and builds nctl from NDEV-20537 successfully
- [ ] `nctl-scan-k8s` workflow runs and builds nctl from NDEV-20537 successfully
- [ ] `nctl-scan-terraform` workflow runs and builds nctl from NDEV-20537 successfully
- [ ] All scans complete and publish results without failing the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)